### PR TITLE
Revert "Add edition field to artwork transformer [API-358]"

### DIFF
--- a/app/Transformers/ArtworkTransformer.php
+++ b/app/Transformers/ArtworkTransformer.php
@@ -38,8 +38,6 @@ class ArtworkTransformer extends BaseTransformer
             'artwork_places' => $this->mapToArray($datum->artwork_places, 'getArtworkPlace'),
             'artwork_dates' => $this->mapToArray($datum->artwork_dates, 'getArtworkDate'),
             'artwork_catalogues' => $this->mapToArray($datum->artwork_catalogues, 'getArtworkCatalogue'),
-
-            'edition' => $datum->edition,
         ];
 
         /**


### PR DESCRIPTION
This reverts commit 7aa1f280ed2f83f19236ac76f2db5892f6c70e64 and PR https://github.com/art-institute-of-chicago/data-service-collections/pull/13. We don't need to include fields in the transformer, such as `edition`, that are simply passed thru, ie. the `*Transformers` are only for transforming the data.